### PR TITLE
#182 [CLOUD-5740] fix: get alert severity info from event data

### DIFF
--- a/src/spaceone/monitoring/service/event_service.py
+++ b/src/spaceone/monitoring/service/event_service.py
@@ -190,7 +190,7 @@ class EventService(BaseService):
         event_data['webhook_id'] = webhook_data['webhook_id']
         event_data['project_id'] = webhook_data['project_id']
         event_data['domain_id'] = webhook_data['domain_id']
-        event_data['severity'] = webhook_data.get('severity', 'NONE')
+        event_data['severity'] = event_data.get('severity', 'NONE')
 
         event_rule_mgr: EventRuleManager = self.locator.get_manager('EventRuleManager')
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description

### Known issue
