### PR TITLE
feat: add dynamic event match rule based on Provider and Account

### DIFF
--- a/src/spaceone/monitoring/manager/identity_manager.py
+++ b/src/spaceone/monitoring/manager/identity_manager.py
@@ -4,7 +4,6 @@ from spaceone.core import cache
 from spaceone.core.manager import BaseManager
 from spaceone.core.connector.space_connector import SpaceConnector
 
-
 _LOGGER = logging.getLogger(__name__)
 
 _GET_RESOURCE_METHODS = {
@@ -37,3 +36,6 @@ class IdentityManager(BaseManager):
             return self.get_project(resource_id, domain_id)
         elif resource_type == 'identity.ServiceAccount':
             return self.get_service_account(resource_id, domain_id)
+
+    def list_service_accounts(self, query, domain_id):
+        return self.identity_connector.dispatch('ServiceAccount.list', {'query': query, 'domain_id': domain_id})

--- a/src/spaceone/monitoring/model/event_rule_model.py
+++ b/src/spaceone/monitoring/model/event_rule_model.py
@@ -18,7 +18,7 @@ class EventRule(MongoModel):
     name = StringField(max_length=255, default='')
     order = IntField(required=True)
     conditions = ListField(EmbeddedDocumentField(EventRuleCondition))
-    conditions_policy = StringField(max_length=20, choices=('ALL', 'ANY'))
+    conditions_policy = StringField(max_length=20, choices=('ALL', 'ANY', 'ALWAYS'))
     actions = DictField()
     options = EmbeddedDocumentField(EventRuleOptions, default=EventRuleOptions)
     tags = DictField()


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
Based on the account field, if the field in the target account is matched, 
it is implemented to map the service account or project.
Additionally, when conditions_policy is alway, the action proceeds regardless of the condition. (#196)
